### PR TITLE
Update gtfs.py to strip df header whitespace

### DIFF
--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -152,7 +152,7 @@ class GTFS:
         # Set the analysis date as "date unaware"
         self.date = None
 
-    def read_clean_feed(filepath,dtype=None,parse_dates=False,skipinitialspace=True):
+    def _load_clean_feed(filepath,dtype=None,parse_dates=False,skipinitialspace=True):
         df = pd.read_csv(
             filepath,
             dtype=dtype,
@@ -183,7 +183,7 @@ class GTFS:
                         filepaths[req] = file
 
             # Create pandas objects of the entire feed
-            agency = self.read_clean_feed(
+            agency = self._load_clean_feed(
                 zip_file.open(filepaths["agency.txt"]),
                 dtype={
                     "agency_id": str,
@@ -197,7 +197,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            stops = self.read_clean_feed(
+            stops = self._load_clean_feed(
                 zip_file.open(filepaths["stops.txt"]),
                 dtype={
                     "stop_id": str,
@@ -217,7 +217,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            routes = self.read_clean_feed(
+            routes = self._load_clean_feed(
                 zip_file.open(filepaths["routes.txt"]),
                 dtype={
                     "route_id": str,
@@ -233,7 +233,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            trips = self.read_clean_feed(
+            trips = self._load_clean_feed(
                 zip_file.open(filepaths["trips.txt"]),
                 dtype={
                     "route_id": str,
@@ -249,7 +249,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            stop_times = self.read_clean_feed(
+            stop_times = self._load_clean_feed(
                 zip_file.open(filepaths["stop_times.txt"]),
                 dtype={
                     "trip_id": str,
@@ -267,7 +267,7 @@ class GTFS:
             )
 
             if filepaths["calendar.txt"] in zip_file.namelist():
-                calendar = self.read_clean_feed(
+                calendar = self._load_clean_feed(
                     zip_file.open(filepaths["calendar.txt"]),
                     dtype={
                         "service_id": str,
@@ -290,7 +290,7 @@ class GTFS:
                 calendar = None
 
             if filepaths["calendar_dates.txt"] in zip_file.namelist():
-                calendar_dates = self.read_clean_feed(
+                calendar_dates = self._load_clean_feed(
                     zip_file.open(filepaths["calendar_dates.txt"]),
                     dtype={"service_id": str, "date": str, "exception_type": int},
                     skipinitialspace=True,
@@ -303,7 +303,7 @@ class GTFS:
                 calendar_dates = None
 
             if filepaths["fare_attributes.txt"] in zip_file.namelist():
-                fare_attributes = self.read_clean_feed(
+                fare_attributes = self._load_clean_feed(
                     zip_file.open(filepaths["fare_attributes.txt"]),
                     dtype={
                         "fare_id": str,
@@ -320,7 +320,7 @@ class GTFS:
                 fare_attributes = None
 
             if filepaths["fare_rules.txt"] in zip_file.namelist():
-                fare_rules = self.read_clean_feed(
+                fare_rules = self._load_clean_feed(
                     zip_file.open(filepaths["fare_rules.txt"]),
                     dtype={
                         "fare_id": str,
@@ -335,7 +335,7 @@ class GTFS:
                 fare_rules = None
 
             if filepaths["shapes.txt"] in zip_file.namelist():
-                shapes = self.read_clean_feed(
+                shapes = self._load_clean_feed(
                     zip_file.open(filepaths["shapes.txt"]),
                     dtype={
                         "shape_id": str,
@@ -350,7 +350,7 @@ class GTFS:
                 shapes = None
 
             if filepaths["frequencies.txt"] in zip_file.namelist():
-                frequencies = self.read_clean_feed(
+                frequencies = self._load_clean_feed(
                     zip_file.open(filepaths["frequencies.txt"]),
                     dtype={
                         "trip_id": str,
@@ -366,7 +366,7 @@ class GTFS:
                 frequencies = None
 
             if filepaths["transfers.txt"] in zip_file.namelist():
-                transfers = self.read_clean_feed(
+                transfers = self._load_clean_feed(
                     zip_file.open(filepaths["transfers.txt"]),
                     dtype={
                         "from_stop_id": str,
@@ -380,7 +380,7 @@ class GTFS:
                 transfers = None
 
             if filepaths["pathways.txt"] in zip_file.namelist():
-                pathways = self.read_clean_feed(
+                pathways = self._load_clean_feed(
                     zip_file.open(filepaths["pathways.txt"]),
                     dtype={
                         "pathway_id": str,
@@ -402,7 +402,7 @@ class GTFS:
                 pathways = None
 
             if filepaths["levels.txt"] in zip_file.namelist():
-                levels = self.read_clean_feed(
+                levels = self._load_clean_feed(
                     zip_file.open(filepaths["levels.txt"]),
                     dtype={"level_id": str, "level_index": float, "level_name": str},
                     skipinitialspace=True,
@@ -411,7 +411,7 @@ class GTFS:
                 levels = None
 
             if filepaths["translations.txt"] in zip_file.namelist():
-                translations = self.read_clean_feed(
+                translations = self._load_clean_feed(
                     zip_file.open(filepaths["translations.txt"]),
                     dtype={
                         "table_name": str,
@@ -424,7 +424,7 @@ class GTFS:
                     },
                     skipinitialspace=True,
                 )
-                feed_info = self.read_clean_feed(
+                feed_info = self._load_clean_feed(
                     zip_file.open(filepaths["feed_info.txt"]),
                     dtype={
                         "feed_publisher_name": str,
@@ -440,7 +440,7 @@ class GTFS:
                     skipinitialspace=True,
                 )
             elif filepaths["feed_info.txt"] in zip_file.namelist():
-                feed_info = self.read_clean_feed(
+                feed_info = self._load_clean_feed(
                     zip_file.open(filepaths["feed_info.txt"]),
                     dtype={
                         "feed_publisher_name": str,

--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -283,8 +283,8 @@ class GTFS:
                     },
                     skipinitialspace=True,
                 )
-                calendar["start_date"] = pd.to_datetime(calendar["start_date"]).dt.date
-                calendar["end_date"] = pd.to_datetime(calendar["end_date"]).dt.date
+                calendar["start_date"] = pd.to_datetime(calendar["start_date"], format='%Y%m%d').dt.date
+                calendar["end_date"] = pd.to_datetime(calendar["end_date"], format='%Y%m%d').dt.date
 
             else:
                 calendar = None
@@ -298,7 +298,7 @@ class GTFS:
                 if calendar_dates.shape[0] == 0:
                     calendar_dates = None
                 else:
-                    calendar_dates["date"] = pd.to_datetime(calendar_dates["date"]).dt.date
+                    calendar_dates["date"] = pd.to_datetime(calendar_dates["date"], format='%Y%m%d').dt.date
             else:
                 calendar_dates = None
 

--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -152,8 +152,18 @@ class GTFS:
         # Set the analysis date as "date unaware"
         self.date = None
 
-    @staticmethod
-    def load_zip(filepath):
+    def read_clean_feed(filepath,dtype=None,parse_dates=False,skipinitialspace=True):
+        df = pd.read_csv(
+            filepath,
+            dtype=dtype,
+            parse_dates=parse_dates,
+            skipinitialspace=skipinitialspace,
+        )
+        df.columns = df.columns.str.strip()
+        return df
+    
+    @classmethod
+    def load_zip(self, filepath):
         """Creates a :class:`GTFS` object from a zipfile containing the
         appropriate data.
 
@@ -173,7 +183,7 @@ class GTFS:
                         filepaths[req] = file
 
             # Create pandas objects of the entire feed
-            agency = pd.read_csv(
+            agency = self.read_clean_feed(
                 zip_file.open(filepaths["agency.txt"]),
                 dtype={
                     "agency_id": str,
@@ -187,7 +197,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            stops = pd.read_csv(
+            stops = self.read_clean_feed(
                 zip_file.open(filepaths["stops.txt"]),
                 dtype={
                     "stop_id": str,
@@ -207,7 +217,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            routes = pd.read_csv(
+            routes = self.read_clean_feed(
                 zip_file.open(filepaths["routes.txt"]),
                 dtype={
                     "route_id": str,
@@ -223,7 +233,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            trips = pd.read_csv(
+            trips = self.read_clean_feed(
                 zip_file.open(filepaths["trips.txt"]),
                 dtype={
                     "route_id": str,
@@ -239,7 +249,7 @@ class GTFS:
                 },
                 skipinitialspace=True,
             )
-            stop_times = pd.read_csv(
+            stop_times = self.read_clean_feed(
                 zip_file.open(filepaths["stop_times.txt"]),
                 dtype={
                     "trip_id": str,
@@ -257,7 +267,7 @@ class GTFS:
             )
 
             if filepaths["calendar.txt"] in zip_file.namelist():
-                calendar = pd.read_csv(
+                calendar = self.read_clean_feed(
                     zip_file.open(filepaths["calendar.txt"]),
                     dtype={
                         "service_id": str,
@@ -280,7 +290,7 @@ class GTFS:
                 calendar = None
 
             if filepaths["calendar_dates.txt"] in zip_file.namelist():
-                calendar_dates = pd.read_csv(
+                calendar_dates = self.read_clean_feed(
                     zip_file.open(filepaths["calendar_dates.txt"]),
                     dtype={"service_id": str, "date": str, "exception_type": int},
                     skipinitialspace=True,
@@ -293,7 +303,7 @@ class GTFS:
                 calendar_dates = None
 
             if filepaths["fare_attributes.txt"] in zip_file.namelist():
-                fare_attributes = pd.read_csv(
+                fare_attributes = self.read_clean_feed(
                     zip_file.open(filepaths["fare_attributes.txt"]),
                     dtype={
                         "fare_id": str,
@@ -310,7 +320,7 @@ class GTFS:
                 fare_attributes = None
 
             if filepaths["fare_rules.txt"] in zip_file.namelist():
-                fare_rules = pd.read_csv(
+                fare_rules = self.read_clean_feed(
                     zip_file.open(filepaths["fare_rules.txt"]),
                     dtype={
                         "fare_id": str,
@@ -325,7 +335,7 @@ class GTFS:
                 fare_rules = None
 
             if filepaths["shapes.txt"] in zip_file.namelist():
-                shapes = pd.read_csv(
+                shapes = self.read_clean_feed(
                     zip_file.open(filepaths["shapes.txt"]),
                     dtype={
                         "shape_id": str,
@@ -340,7 +350,7 @@ class GTFS:
                 shapes = None
 
             if filepaths["frequencies.txt"] in zip_file.namelist():
-                frequencies = pd.read_csv(
+                frequencies = self.read_clean_feed(
                     zip_file.open(filepaths["frequencies.txt"]),
                     dtype={
                         "trip_id": str,
@@ -356,7 +366,7 @@ class GTFS:
                 frequencies = None
 
             if filepaths["transfers.txt"] in zip_file.namelist():
-                transfers = pd.read_csv(
+                transfers = self.read_clean_feed(
                     zip_file.open(filepaths["transfers.txt"]),
                     dtype={
                         "from_stop_id": str,
@@ -370,7 +380,7 @@ class GTFS:
                 transfers = None
 
             if filepaths["pathways.txt"] in zip_file.namelist():
-                pathways = pd.read_csv(
+                pathways = self.read_clean_feed(
                     zip_file.open(filepaths["pathways.txt"]),
                     dtype={
                         "pathway_id": str,
@@ -392,7 +402,7 @@ class GTFS:
                 pathways = None
 
             if filepaths["levels.txt"] in zip_file.namelist():
-                levels = pd.read_csv(
+                levels = self.read_clean_feed(
                     zip_file.open(filepaths["levels.txt"]),
                     dtype={"level_id": str, "level_index": float, "level_name": str},
                     skipinitialspace=True,
@@ -401,7 +411,7 @@ class GTFS:
                 levels = None
 
             if filepaths["translations.txt"] in zip_file.namelist():
-                translations = pd.read_csv(
+                translations = self.read_clean_feed(
                     zip_file.open(filepaths["translations.txt"]),
                     dtype={
                         "table_name": str,
@@ -414,7 +424,7 @@ class GTFS:
                     },
                     skipinitialspace=True,
                 )
-                feed_info = pd.read_csv(
+                feed_info = self.read_clean_feed(
                     zip_file.open(filepaths["feed_info.txt"]),
                     dtype={
                         "feed_publisher_name": str,
@@ -430,7 +440,7 @@ class GTFS:
                     skipinitialspace=True,
                 )
             elif filepaths["feed_info.txt"] in zip_file.namelist():
-                feed_info = pd.read_csv(
+                feed_info = self.read_clean_feed(
                     zip_file.open(filepaths["feed_info.txt"]),
                     dtype={
                         "feed_publisher_name": str,
@@ -451,7 +461,7 @@ class GTFS:
                 feed_info = None
 
             if filepaths["attributions.txt"] in zip_file.namelist():
-                attributions = pd.read_csv(
+                attributions = self.read_clean_feed(
                     zip_file.open("attributions.txt"),
                     dtype={
                         "attribution_id": str,


### PR DESCRIPTION
Sketched a possible solution for reading GTFS feeds that contain .txt files with headers with white space that should be stripped to be otherwise readable, as per https://github.com/wklumpen/gtfs-lite/issues/38

I created a wrapper function `read_clean_feed()` to read CSVs using Pandas, ensure white space is stripped from columns (`df.columns = df.columns.str.strip()`) and return the dataframe.   This meant little had to be changed other than changing `pd.read_csv` to `self.read_clean_feed`.  

In addition, I changed load_zip to an `@classmethod` instead of `@staticmethod`.  This seemed required in order to be able to refer to `self` to use the new function.   However, I haven't used decorators before -- its possible I haven't fully understood the consequences of that change.

I tested out this change with the following zipped GTFS feed:
[20230509_010334_RENFE_AVLD.zip](https://github.com/wklumpen/gtfs-lite/files/11474145/20230509_010334_RENFE_AVLD.zip)

*without the edit*:
```
>>> import gtfslite.gtfs
>>> test = gtfslite.gtfs.GTFS.load_zip('data/20230509_010334_RENFE_AVLD.zip')
Traceback (most recent call last):
  File "C:\Users\carlh\miniconda3\lib\site-packages\pandas\core\indexes\base.py", line 3080, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas\_libs\index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas\_libs\index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas\_libs\hashtable_class_helper.pxi", line 4554, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas\_libs\hashtable_class_helper.pxi", line 4562, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'end_date'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\gtfs-lite\gtfslite\gtfs.py", line 277, in load_zip
    calendar["start_date"] = pd.to_datetime(calendar["start_date"]).dt.date
  File "C:\Users\carlh\miniconda3\lib\site-packages\pandas\core\frame.py", line 3024, in __getitem__
    indexer = self.columns.get_loc(key)
  File "C:\Users\carlh\miniconda3\lib\site-packages\pandas\core\indexes\base.py", line 3082, in get_loc
    raise KeyError(key) from err
KeyError: 'end_date'
```

manually reading calendar.txt from that zip file (copied to the data directory), it looks like this:
```
df = pd.read_csv('data/calendar.txt',skipinitialspace=True)
Index(['service_id', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday',
       'saturday', 'sunday', 'start_date',
       'end_date
                                                                      '],
      dtype='object')
```

That causes a key error when calling `pd.to_datetime()` because `end_date` couldn't be located, as its effectively misnamed with a big whitespace suffix in the source file.

*with the edit*:
```
>>> import gtfslite.gtfs
>>> test = gtfslite.gtfs.GTFS.load_zip('data/20230509_010334_RENFE_AVLD.zip')
>>> test
<gtfslite.gtfs.GTFS object at 0x000001E70E920BB0>
>>> test.calendar
                      service_id  monday  tuesday  wednesday  ...  saturday  sunday  start_date    end_date
0     2023-05-082023-06-09001651    True     True       True  ...      True    True  2023-05-08  1970-01-01
1     2023-05-082023-06-09001653    True     True       True  ...      True    True  2023-05-08  1970-01-01
2     2023-05-082023-06-30001901    True     True       True  ...      True    True  2023-05-08  1970-01-01
3     2023-05-082023-06-30001902    True     True       True  ...      True    True  2023-05-08  1970-01-01
4     2023-05-082023-06-30001931    True     True       True  ...      True    True  2023-05-08  1970-01-01
...                          ...     ...      ...        ...  ...       ...     ...         ...         ...
3425  2023-05-082023-05-28389071    True     True       True  ...      True    True  2023-05-08  1970-01-01
3426  2023-05-082023-05-28389081    True     True       True  ...      True    True  2023-05-08  1970-01-01
3427  2023-05-082023-05-28389091    True     True       True  ...      True    True  2023-05-08  1970-01-01
3428  2023-05-082023-12-09941841    True     True       True  ...      True    True  2023-05-08  1970-01-01
3429  2023-05-082023-12-09942751    True     True       True  ...      True    True  2023-05-08  1970-01-01

[3430 rows x 10 columns]
```