### PR TITLE
Parse frequencies.txt end and start times as time deltas

### DIFF
--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -359,9 +359,10 @@ class GTFS:
                         "headway_secs": int,
                         "exact_times": int,
                     },
-                    parse_dates=["start_time", "end_time"],
                     skipinitialspace=True,
                 )
+                frequencies["start_time"] = pd.to_timedelta(frequencies["start_time"])
+                frequencies["end_time"] = pd.to_timedelta(frequencies["end_time"])
             else:
                 frequencies = None
 


### PR DESCRIPTION
This last change, modifying the parsing of start_time and end_time, was missed in the previous pull requests I think, sorry; it addresses #40 .

Hopefully its all clear, thanks!