### PR TITLE
Change method from append to extend to concatenate lists

### DIFF
--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -579,7 +579,7 @@ class GTFS:
             ].service_id.tolist()
             if self.calendar_dates is not None:
                 # Add service ids in the calendar_dates
-                service_ids.append(
+                service_ids.extend(
                     self.calendar_dates[
                         (self.calendar_dates.date == date) & (self.calendar_dates.exception_type == 1)
                     ].service_id.tolist()


### PR DESCRIPTION
Appending a list to a list means to insert the second list as an item in the list. Which is not what we want to do.
Extend will insert all the items of the second list into the first list.

This needs to change because in earlier versions, pandas objects were used instead of lists, and the append method works differently there.