### PR TITLE
Fix `routes_summary` for pandas v2

### DIFF
--- a/gtfslite/gtfs.py
+++ b/gtfslite/gtfs.py
@@ -844,15 +844,16 @@ class GTFS:
         summary = pd.merge(route_trips, first_departures, on=["route_id"])
         summary = pd.merge(summary, last_arrivals, on=["route_id"])
         summary["service_time"] = (
-            summary.arrival_time.str.split(":", -1, expand=True)[0].astype(int)
-            + summary.arrival_time.str.split(":", -1, expand=True)[1].astype(int) / 60.0
-            + summary.arrival_time.str.split(":", -1, expand=True)[2].astype(int)
+            summary.arrival_time.str.split(":", n=-1, expand=True)[0].astype(int)
+            + summary.arrival_time.str.split(":", n=-1, expand=True)[1].astype(int)
+            / 60.0
+            + summary.arrival_time.str.split(":", n=-1, expand=True)[2].astype(int)
             / 3600.0
         ) - (
-            summary.departure_time.str.split(":", -1, expand=True)[0].astype(int)
-            + summary.departure_time.str.split(":", -1, expand=True)[1].astype(int)
+            summary.departure_time.str.split(":", n=-1, expand=True)[0].astype(int)
+            + summary.departure_time.str.split(":", n=-1, expand=True)[1].astype(int)
             / 60.0
-            + summary.departure_time.str.split(":", -1, expand=True)[2].astype(int)
+            + summary.departure_time.str.split(":", n=-1, expand=True)[2].astype(int)
             / 3600.0
         )
         summary["average_headway"] = 60 * summary.service_time / summary.trips

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="gtfs-lite",
-    version="0.2.1",
+    version="0.2.2",
     author="Willem Klumpenhouwer",
     author_email="willem@klumpentown.com",
     description="A lightweight Pandas-driven package for analyzing static GTFS feeds.",

--- a/tests/test_route_summary.py
+++ b/tests/test_route_summary.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Tests for the GTFS route summary methods."""
+
+import pandas as pd
+import pytest
+
+from gtfslite import GTFS
+
+
+@pytest.fixture(name="gtfs_data")
+def fix_gtfs_data(feed_zipfile) -> GTFS:
+    """Load GTFS data."""
+    return GTFS.load_zip(feed_zipfile)
+
+
+def test_routes_summary(gtfs_data: GTFS, test_date):
+    """Test `routes_summary` method produces result."""
+    summary = gtfs_data.routes_summary(test_date)
+    assert isinstance(summary, pd.DataFrame)
+
+    expected_columns = {
+        "route_id",
+        "trips",
+        "first_departure",
+        "last_arrival",
+        "average_headway",
+    }
+
+    assert (
+        set(summary.columns.tolist()) >= expected_columns
+    ), "missing routes summary columns"


### PR DESCRIPTION
Fixes error in `GTFS.routes_summary` where calls to `pandas.Series.str.split()` use a positional parameter that should be keyword-only.

- Fixed by swapping the `n` parameter in split to use the keyword e.g. `split(":", -1)` becomes `split(":", n=-1)`.
- Also, added basic text for the `routes_summary` method to make sure the problem is fixed.
- Bumped patch version to 0.2.2